### PR TITLE
Fix NPE in case the content-type is empty in the response

### DIFF
--- a/oauth2library/src/main/java/ca/mimic/oauth2library/Utils.java
+++ b/oauth2library/src/main/java/ca/mimic/oauth2library/Utils.java
@@ -14,7 +14,7 @@ import okhttp3.Route;
 class Utils {
 
     protected static boolean isJsonResponse(Response response) {
-        return response.body() != null && response.body().contentType().subtype().equals("json");
+        return response.body() != null && response.body().contentType() != null && response.body().contentType().subtype().equals("json");
     }
 
     protected static Authenticator getAuthenticator(final OAuth2Client oAuth2Client,


### PR DESCRIPTION
Our Oauth server is behind a proxy which means that if the server is down the response doesn't contain a proper `contentType` which leads to a NPE