### PR TITLE
Expose the Authenticator to the Builder

### DIFF
--- a/oauth2library/src/main/java/ca/mimic/oauth2library/Access.java
+++ b/oauth2library/src/main/java/ca/mimic/oauth2library/Access.java
@@ -2,6 +2,7 @@ package ca.mimic.oauth2library;
 
 import java.io.IOException;
 
+import okhttp3.Authenticator;
 import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -58,7 +59,9 @@ public class Access {
                                               final OkHttpClient okHttpClient,
                                               final Request request,
                                               final AuthState authState) throws IOException {
-        Response response = okHttpClient.newBuilder().authenticator(Utils.getAuthenticator(oAuth2Client, authState))
+
+        Authenticator authenticator = oAuth2Client.getAuthenticator() == null ? Utils.getAuthenticator(oAuth2Client, authState) : oAuth2Client.getAuthenticator();
+        Response response = okHttpClient.newBuilder().authenticator(authenticator)
                 .build().newCall(request).execute();
 
         return new OAuthResponse(response);

--- a/oauth2library/src/main/java/ca/mimic/oauth2library/AuthState.java
+++ b/oauth2library/src/main/java/ca/mimic/oauth2library/AuthState.java
@@ -2,6 +2,7 @@ package ca.mimic.oauth2library;
 
 class AuthState {
     protected static final int ACCESS_TOKEN = 0;
+    protected static final int ACCESS_TOKEN_NO_RETRY = 2;
     protected static final int REFRESH_TOKEN = 1;
 
     private static final int NO_AUTH = 0;
@@ -13,6 +14,13 @@ class AuthState {
             NO_AUTH,
             BASIC_AUTH,
             AUTHORIZATION_AUTH,
+            FINAL_AUTH
+    };
+
+
+    private static final int[] ACCESS_STATES_NO_RETRY = new int[]{
+            NO_AUTH,
+            BASIC_AUTH,
             FINAL_AUTH
     };
 
@@ -35,6 +43,8 @@ class AuthState {
             case REFRESH_TOKEN:
                 state = REFRESH_STATES;
                 break;
+        case ACCESS_TOKEN_NO_RETRY:
+            state = ACCESS_STATES_NO_RETRY;
         }
     }
 

--- a/oauth2library/src/main/java/ca/mimic/oauth2library/AuthState.java
+++ b/oauth2library/src/main/java/ca/mimic/oauth2library/AuthState.java
@@ -2,7 +2,6 @@ package ca.mimic.oauth2library;
 
 class AuthState {
     protected static final int ACCESS_TOKEN = 0;
-    protected static final int ACCESS_TOKEN_NO_RETRY = 2;
     protected static final int REFRESH_TOKEN = 1;
 
     private static final int NO_AUTH = 0;
@@ -14,13 +13,6 @@ class AuthState {
             NO_AUTH,
             BASIC_AUTH,
             AUTHORIZATION_AUTH,
-            FINAL_AUTH
-    };
-
-
-    private static final int[] ACCESS_STATES_NO_RETRY = new int[]{
-            NO_AUTH,
-            BASIC_AUTH,
             FINAL_AUTH
     };
 
@@ -43,8 +35,6 @@ class AuthState {
             case REFRESH_TOKEN:
                 state = REFRESH_STATES;
                 break;
-        case ACCESS_TOKEN_NO_RETRY:
-            state = ACCESS_STATES_NO_RETRY;
         }
     }
 

--- a/oauth2library/src/main/java/ca/mimic/oauth2library/OAuth2Client.java
+++ b/oauth2library/src/main/java/ca/mimic/oauth2library/OAuth2Client.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import okhttp3.Authenticator;
 import okhttp3.OkHttpClient;
 
 public class OAuth2Client {
@@ -18,6 +19,8 @@ public class OAuth2Client {
     private String username;
     private String password;
 
+    private Authenticator authenticator;
+
     private Map<String, String> parameters;
 
     private OAuth2Client(Builder builder) {
@@ -30,6 +33,7 @@ public class OAuth2Client {
         this.grantType = builder.grantType;
         this.okHttpClient= builder.okHttpClient;
         this.parameters = builder.parameters;
+        this.authenticator = builder.authenticator;
     }
 
     protected String getScope() {
@@ -58,6 +62,10 @@ public class OAuth2Client {
 
     protected String getPassword() {
         return password;
+    }
+
+    protected Authenticator getAuthenticator(){
+        return authenticator;
     }
 
     public OAuthResponse refreshAccessToken(String refreshToken) throws IOException {
@@ -143,6 +151,8 @@ public class OAuth2Client {
         private String username;
         private String password;
 
+        private Authenticator authenticator;
+
         private OkHttpClient okHttpClient;
 
         private Map<String, String> parameters;
@@ -160,6 +170,7 @@ public class OAuth2Client {
         public Builder(String clientId, String clientSecret, String site) {
             this.username = null;
             this.password = null;
+            this.authenticator = null;
             this.clientId = clientId;
             this.clientSecret = clientSecret;
             this.site = site;
@@ -193,6 +204,11 @@ public class OAuth2Client {
 
         public Builder parameters(Map<String, String> parameters) {
             this.parameters = parameters;
+            return this;
+        }
+
+        public Builder authenticator(Authenticator authenticator){
+            this.authenticator = authenticator;
             return this;
         }
 


### PR DESCRIPTION
In order to override the current default behaviour which force retries by default 