### PR TITLE
Add proguard rules for OAuthError

### DIFF
--- a/oauth2library/proguard-rules.txt
+++ b/oauth2library/proguard-rules.txt
@@ -9,6 +9,9 @@
 # Application classes that will be serialized/deserialized over Gson
 -keep class ca.mimic.oauth2library.Token { *; }
 -keepclassmembers class ca.mimic.oauth2library.Token { *; }
+-keepclassmembers class ca.mimic.oauth2library.OAuthError {
+    protected <fields>;
+}
 
 # Prevent proguard from stripping interface information from TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)


### PR DESCRIPTION
AGP 3.6.0 uses newer R8 version which stripes all protected fields if you are using `-allowaccessmodification` flag.